### PR TITLE
Add basic Slack webhook handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # slack-to-gpt-and-back
-Slackbot integrated with OpenAI response API with predefined prompt ant tools
+
+Slackbot integrated with OpenAI response API with predefined prompt and tools.
+
+## Slack webhook handler
+
+`slack_webhook_handler.py` implements a small Flask application that accepts
+Slack message webhooks. It retrieves the user's full profile, forwards the text
+prompt to OpenAI using the responses API and sends the AI reply back to the
+original Slack channel.
+
+### Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables:
+   - `SLACK_BOT_TOKEN` – Bot token to call Slack APIs.
+   - `OPENAI_API_KEY` – API key for OpenAI.
+   - `OPENAI_PROMPT_ID` – ID of the predefined OpenAI prompt.
+   - `OPENAI_PROMPT_VERSION` – Prompt version for your predefined prompt.
+3. Start the server:
+   ```bash
+   python slack_webhook_handler.py
+   ```
+
+The server exposes `/slack/webhook` for Slack to send events.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+slack_sdk
+openai

--- a/slack_webhook_handler.py
+++ b/slack_webhook_handler.py
@@ -1,0 +1,64 @@
+import os
+from flask import Flask, request, jsonify
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from openai import OpenAI
+
+SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OPENAI_PROMPT_ID = os.environ.get("OPENAI_PROMPT_ID")
+OPENAI_PROMPT_VERSION = os.environ.get("OPENAI_PROMPT_VERSION")
+
+app = Flask(__name__)
+slack_client = WebClient(token=SLACK_BOT_TOKEN)
+openai_client = OpenAI()
+
+@app.route("/slack/webhook", methods=["POST"])
+def slack_webhook():
+    data = request.get_json(force=True)
+
+    if isinstance(data, dict) and data.get("type") == "url_verification":
+        return jsonify({"challenge": data.get("challenge")})
+
+    event = None
+    if isinstance(data, list) and data:
+        event = data[0]
+    elif isinstance(data, dict):
+        event = data.get("event", data)
+
+    if not event or event.get("type") != "message":
+        return "ignored", 200
+
+    user_id = event.get("user")
+    text = event.get("text", "")
+    channel = event.get("channel")
+
+    profile = {}
+    if user_id:
+        try:
+            profile_resp = slack_client.users_profile_get(user=user_id)
+            if profile_resp["ok"]:
+                profile = profile_resp["profile"]
+        except SlackApiError:
+            pass
+
+    prompt = {
+        "id": OPENAI_PROMPT_ID,
+        "version": OPENAI_PROMPT_VERSION,
+        "input": text,
+    }
+    ai_response_text = ""
+    try:
+        oa_resp = openai_client.responses.create(prompt=prompt)
+        ai_response_text = getattr(oa_resp, "text", "") or oa_resp.get("text", "")
+    except Exception as e:
+        app.logger.exception("OpenAI responses API call failed")
+        ai_response_text = f"Error calling OpenAI: {e}"
+
+    if ai_response_text and channel:
+        slack_client.chat_postMessage(channel=channel, text=ai_response_text)
+
+    return "ok", 200
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))


### PR DESCRIPTION
## Summary
- implement `slack_webhook_handler.py` to receive Slack `message` events
- fetch the user's profile and call OpenAI responses API
- send the OpenAI reply back to Slack
- document how to run the handler
- add Python requirements
- fix version handling and error logging

## Testing
- `python -m py_compile slack_webhook_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_686d1da949ac832bb50eadf673329965