### PR TITLE
Fix SSL certificate errors for Slack client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ original Slack channel.
    ```bash
    pip install -r requirements.txt
    ```
+   The project uses `certifi` so that SSL requests to Slack work even on
+   systems without global certificate bundles.
 2. Set environment variables:
    - `SLACK_BOT_TOKEN` – Bot token to call Slack APIs.
    - `OPENAI_API_KEY` – API key for OpenAI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
 slack_sdk
 openai
+certifi
 pytest==8.4.1

--- a/slack_webhook_handler.py
+++ b/slack_webhook_handler.py
@@ -2,6 +2,8 @@ import os
 from flask import Flask, request, jsonify
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
+import ssl
+import certifi
 from openai import OpenAI
 
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
@@ -10,7 +12,11 @@ OPENAI_PROMPT_ID = os.environ.get("OPENAI_PROMPT_ID")
 OPENAI_PROMPT_VERSION = os.environ.get("OPENAI_PROMPT_VERSION")
 
 app = Flask(__name__)
-slack_client = WebClient(token=SLACK_BOT_TOKEN)
+
+# Use certifi to provide CA certificates for SSL verification
+ssl_context = ssl.create_default_context(cafile=certifi.where())
+slack_client = WebClient(token=SLACK_BOT_TOKEN, ssl=ssl_context)
+
 openai_client = OpenAI()
 
 @app.route("/slack/webhook", methods=["POST"])


### PR DESCRIPTION
## Summary
- ensure Slack API calls work even without system certificates by using certifi for the SSL context
- document certifi usage in README
- add certifi dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2ab0f6b0832b9b2adde538fb3b84